### PR TITLE
Version 2 12 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Tideland Go REST Server Library
 
+## 2017-02-12
+
+- Some renamings in *Request*  and *Response*, sadly
+  to the previous minor release
+- More convenience helpers for testing
+- Adopted new testing to more packages
+- Using http package constants instead of own
+  plain strings
+- Added documentation to restaudit
+
 ## 2017-02-10
 
 - Extended *Request* and *Response* of *restaudit* with some

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ I hope you like it. ;)
 
 ## Version
 
-Version 2.11.0
+Version 2.12.0
 
 ## Packages
 

--- a/jwt/errors.go
+++ b/jwt/errors.go
@@ -1,6 +1,6 @@
 // Tideland Go REST Server Library - JSON Web Token - Errors
 //
-// Copyright (C) 2016 Frank Mueller / Tideland / Oldenburg / Germany
+// Copyright (C) 2016-2017 Frank Mueller / Tideland / Oldenburg / Germany
 //
 // All rights reserved. Use of this source code is governed
 // by the new BSD license.

--- a/jwt/header_test.go
+++ b/jwt/header_test.go
@@ -1,6 +1,6 @@
 // Tideland Go REST Server Library - JSON Web Token - Unit Tests
 //
-// Copyright (C) 2016 Frank Mueller / Tideland / Oldenburg / Germany
+// Copyright (C) 2016-2017 Frank Mueller / Tideland / Oldenburg / Germany
 //
 // All rights reserved. Use of this source code is governed
 // by the new BSD license.
@@ -13,7 +13,6 @@ package jwt_test
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
@@ -46,17 +45,14 @@ func TestDecodeRequest(t *testing.T) {
 	err = mux.Register("test", "jwt", NewTestHandler("jwt", assert, nil, false))
 	assert.Nil(err)
 	// Perform test request.
-	resp := ts.DoRequest(&restaudit.Request{
-		Method: "GET",
-		Path:   "/test/jwt/1234567890",
-		Header: restaudit.KeyValues{"Accept": "application/json"},
-		RequestProcessor: func(req *http.Request) *http.Request {
-			return jwt.AddTokenToRequest(req, jwtIn)
-		},
+	req := restaudit.NewRequest("GET", "/test/jwt/1234567890")
+	req.AddHeader(restaudit.HeaderAccept, restaudit.ApplicationJSON)
+	req.SetRequestProcessor(func(req *http.Request) *http.Request {
+		return jwt.AddTokenToRequest(req, jwtIn)
 	})
-	var claimsOut jwt.Claims
-	err = json.Unmarshal(resp.Body, &claimsOut)
-	assert.Nil(err)
+	resp := ts.DoRequest(req)
+	claimsOut := jwt.Claims{}
+	resp.AssertUnmarshalledBody(&claimsOut)
 	assert.Equal(claimsOut, claimsIn)
 }
 
@@ -76,29 +72,19 @@ func TestDecodeCachedRequest(t *testing.T) {
 	err = mux.Register("test", "jwt", NewTestHandler("jwt", assert, nil, true))
 	assert.Nil(err)
 	// Perform first test request.
-	resp := ts.DoRequest(&restaudit.Request{
-		Method: "GET",
-		Path:   "/test/jwt/1234567890",
-		Header: restaudit.KeyValues{"Accept": "application/json"},
-		RequestProcessor: func(req *http.Request) *http.Request {
-			return jwt.AddTokenToRequest(req, jwtIn)
-		},
+	req := restaudit.NewRequest("GET", "/test/jwt/1234567890")
+	req.AddHeader(restaudit.HeaderAccept, restaudit.ApplicationJSON)
+	req.SetRequestProcessor(func(req *http.Request) *http.Request {
+		return jwt.AddTokenToRequest(req, jwtIn)
 	})
-	var claimsOut jwt.Claims
-	err = json.Unmarshal(resp.Body, &claimsOut)
-	assert.Nil(err)
+	resp := ts.DoRequest(req)
+	claimsOut := jwt.Claims{}
+	resp.AssertUnmarshalledBody(&claimsOut)
 	assert.Equal(claimsOut, claimsIn)
 	// Perform second test request.
-	resp = ts.DoRequest(&restaudit.Request{
-		Method: "GET",
-		Path:   "/test/jwt/1234567890",
-		Header: restaudit.KeyValues{"Accept": "application/json"},
-		RequestProcessor: func(req *http.Request) *http.Request {
-			return jwt.AddTokenToRequest(req, jwtIn)
-		},
-	})
-	err = json.Unmarshal(resp.Body, &claimsOut)
-	assert.Nil(err)
+	resp = ts.DoRequest(req)
+	claimsOut = jwt.Claims{}
+	resp.AssertUnmarshalledBody(&claimsOut)
 	assert.Equal(claimsOut, claimsIn)
 }
 
@@ -118,17 +104,14 @@ func TestVerifyRequest(t *testing.T) {
 	err = mux.Register("test", "jwt", NewTestHandler("jwt", assert, key, false))
 	assert.Nil(err)
 	// Perform test request.
-	resp := ts.DoRequest(&restaudit.Request{
-		Method: "GET",
-		Path:   "/test/jwt/1234567890",
-		Header: restaudit.KeyValues{"Accept": "application/json"},
-		RequestProcessor: func(req *http.Request) *http.Request {
-			return jwt.AddTokenToRequest(req, jwtIn)
-		},
+	req := restaudit.NewRequest("GET", "/test/jwt/1234567890")
+	req.AddHeader(restaudit.HeaderAccept, restaudit.ApplicationJSON)
+	req.SetRequestProcessor(func(req *http.Request) *http.Request {
+		return jwt.AddTokenToRequest(req, jwtIn)
 	})
-	var claimsOut jwt.Claims
-	err = json.Unmarshal(resp.Body, &claimsOut)
-	assert.Nil(err)
+	resp := ts.DoRequest(req)
+	claimsOut := jwt.Claims{}
+	resp.AssertUnmarshalledBody(&claimsOut)
 	assert.Equal(claimsOut, claimsIn)
 }
 
@@ -148,29 +131,18 @@ func TestVerifyCachedRequest(t *testing.T) {
 	err = mux.Register("test", "jwt", NewTestHandler("jwt", assert, key, true))
 	assert.Nil(err)
 	// Perform first test request.
-	resp := ts.DoRequest(&restaudit.Request{
-		Method: "GET",
-		Path:   "/test/jwt/1234567890",
-		Header: restaudit.KeyValues{"Accept": "application/json"},
-		RequestProcessor: func(req *http.Request) *http.Request {
-			return jwt.AddTokenToRequest(req, jwtIn)
-		},
+	req := restaudit.NewRequest("GET", "/test/jwt/1234567890")
+	req.AddHeader(restaudit.HeaderAccept, restaudit.ApplicationJSON)
+	req.SetRequestProcessor(func(req *http.Request) *http.Request {
+		return jwt.AddTokenToRequest(req, jwtIn)
 	})
-	var claimsOut jwt.Claims
-	err = json.Unmarshal(resp.Body, &claimsOut)
-	assert.Nil(err)
+	resp := ts.DoRequest(req)
+	claimsOut := jwt.Claims{}
+	resp.AssertUnmarshalledBody(&claimsOut)
 	assert.Equal(claimsOut, claimsIn)
 	// Perform second test request.
-	resp = ts.DoRequest(&restaudit.Request{
-		Method: "GET",
-		Path:   "/test/jwt/1234567890",
-		Header: restaudit.KeyValues{"Accept": "application/json"},
-		RequestProcessor: func(req *http.Request) *http.Request {
-			return jwt.AddTokenToRequest(req, jwtIn)
-		},
-	})
-	err = json.Unmarshal(resp.Body, &claimsOut)
-	assert.Nil(err)
+	resp = ts.DoRequest(req)
+	resp.AssertUnmarshalledBody(&claimsOut)
 	assert.Equal(claimsOut, claimsIn)
 }
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -13,6 +13,7 @@ package rest
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/tideland/golib/errors"
 )
@@ -83,43 +84,43 @@ func handleJob(handler ResourceHandler, job Job) (bool, error) {
 		return fmt.Sprintf("%s@%s/%s", handler.ID(), job.Domain(), job.Resource())
 	}
 	switch job.Request().Method {
-	case "GET":
+	case http.MethodGet:
 		grh, ok := handler.(GetResourceHandler)
 		if !ok {
 			return false, errors.New(ErrNoGetHandler, errorMessages, id())
 		}
 		return grh.Get(job)
-	case "HEAD":
+	case http.MethodHead:
 		hrh, ok := handler.(HeadResourceHandler)
 		if !ok {
 			return false, errors.New(ErrNoHeadHandler, errorMessages, id())
 		}
 		return hrh.Head(job)
-	case "PUT":
+	case http.MethodPut:
 		prh, ok := handler.(PutResourceHandler)
 		if !ok {
 			return false, errors.New(ErrNoPutHandler, errorMessages, id())
 		}
 		return prh.Put(job)
-	case "POST":
+	case http.MethodPost:
 		prh, ok := handler.(PostResourceHandler)
 		if !ok {
 			return false, errors.New(ErrNoPostHandler, errorMessages, id())
 		}
 		return prh.Post(job)
-	case "PATCH":
+	case http.MethodPatch:
 		prh, ok := handler.(PatchResourceHandler)
 		if !ok {
 			return false, errors.New(ErrNoPatchHandler, errorMessages, id())
 		}
 		return prh.Patch(job)
-	case "DELETE":
+	case http.MethodDelete:
 		drh, ok := handler.(DeleteResourceHandler)
 		if !ok {
 			return false, errors.New(ErrNoDeleteHandler, errorMessages, id())
 		}
 		return drh.Delete(job)
-	case "OPTIONS":
+	case http.MethodOptions:
 		orh, ok := handler.(OptionsResourceHandler)
 		if !ok {
 			return false, errors.New(ErrNoOptionsHandler, errorMessages, id())

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -46,13 +46,13 @@ func TestGetJSON(t *testing.T) {
 	err := mux.Register("test", "json", NewTestHandler("json", assert))
 	assert.Nil(err)
 	// Perform test requests.
-	req := restaudit.NewRequest("GET", "/base/test/json/4711?foo=0815")
+	req := restaudit.NewRequest(assert, "GET", "/base/test/json/4711?foo=0815")
 	req.AddHeader(restaudit.HeaderAccept, restaudit.ApplicationJSON)
 	resp := ts.DoRequest(req)
-	resp.AssertStatus(assert, 200)
-	resp.AssertContentMatch(assert, `.*"ResourceID":"4711".*`)
-	resp.AssertContentMatch(assert, `.*"Query":"0815".*`)
-	resp.AssertContentMatch(assert, `.*"Context":"foo".*`)
+	resp.AssertStatusEquals(200)
+	resp.AssertBodyContains(`"ResourceID":"4711"`)
+	resp.AssertBodyContains(`"Query":"0815"`)
+	resp.AssertBodyContains(`"Context":"foo"`)
 }
 
 // TestPutJSON tests the PUT command with a JSON payload and result.
@@ -65,13 +65,13 @@ func TestPutJSON(t *testing.T) {
 	err := mux.Register("test", "json", NewTestHandler("json", assert))
 	assert.Nil(err)
 	// Perform test requests.
-	req := restaudit.NewRequest("PUT", "/base/test/json/4711")
+	req := restaudit.NewRequest(assert, "PUT", "/base/test/json/4711")
 	reqData := TestRequestData{"foo", "bar", "4711", "0815", ""}
-	req.SetContent(assert, restaudit.ApplicationJSON, reqData)
+	req.SetBody(restaudit.ApplicationJSON, reqData)
 	resp := ts.DoRequest(req)
-	resp.AssertStatus(assert, 200)
+	resp.AssertStatusEquals(200)
 	respData := TestRequestData{}
-	resp.AssertContent(assert, &respData)
+	resp.AssertBody(&respData)
 	assert.Equal(respData, reqData)
 }
 
@@ -85,11 +85,11 @@ func TestGetXML(t *testing.T) {
 	err := mux.Register("test", "xml", NewTestHandler("xml", assert))
 	assert.Nil(err)
 	// Perform test requests.
-	req := restaudit.NewRequest("GET", "/base/test/xml/4711")
+	req := restaudit.NewRequest(assert, "GET", "/base/test/xml/4711")
 	req.AddHeader(restaudit.HeaderAccept, restaudit.ApplicationXML)
 	resp := ts.DoRequest(req)
-	resp.AssertStatus(assert, 200)
-	resp.AssertContentMatch(assert, `.*<ResourceID>4711</ResourceID>.*`)
+	resp.AssertStatusEquals(200)
+	resp.AssertBodyContains(`<ResourceID>4711</ResourceID>`)
 }
 
 // TestPutXML tests the PUT command with a XML payload and result.
@@ -102,13 +102,13 @@ func TestPutXML(t *testing.T) {
 	err := mux.Register("test", "xml", NewTestHandler("xml", assert))
 	assert.Nil(err)
 	// Perform test requests.
-	req := restaudit.NewRequest("PUT", "/base/test/xml/4711")
+	req := restaudit.NewRequest(assert, "PUT", "/base/test/xml/4711")
 	reqData := TestRequestData{"foo", "bar", "4711", "0815", ""}
-	req.SetContent(assert, restaudit.ApplicationXML, reqData)
+	req.SetBody(restaudit.ApplicationXML, reqData)
 	resp := ts.DoRequest(req)
-	resp.AssertStatus(assert, 200)
+	resp.AssertStatusEquals(200)
 	respData := TestRequestData{}
-	resp.AssertContent(assert, &respData)
+	resp.AssertBody(&respData)
 	assert.Equal(respData, reqData)
 }
 
@@ -122,13 +122,13 @@ func TestPutGOB(t *testing.T) {
 	err := mux.Register("test", "gob", NewTestHandler("putgob", assert))
 	assert.Nil(err)
 	// Perform test requests.
-	req := restaudit.NewRequest("POST", "/base/test/gob")
+	req := restaudit.NewRequest(assert, "POST", "/base/test/gob")
 	reqData := TestCounterData{"test", 4711}
-	req.SetContent(assert, restaudit.ApplicationGOB, reqData)
+	req.SetBody(restaudit.ApplicationGOB, reqData)
 	resp := ts.DoRequest(req)
-	resp.AssertStatus(assert, 200)
+	resp.AssertStatusEquals(200)
 	respData := TestCounterData{}
-	resp.AssertContent(assert, &respData)
+	resp.AssertBody(&respData)
 	assert.Equal(respData, reqData)
 }
 
@@ -142,9 +142,9 @@ func TestLongPath(t *testing.T) {
 	err := mux.Register("content", "blog", NewTestHandler("default", assert))
 	assert.Nil(err)
 	// Perform test requests.
-	req := restaudit.NewRequest("GET", "/base/content/blog/2014/09/30/just-a-test")
+	req := restaudit.NewRequest(assert, "GET", "/base/content/blog/2014/09/30/just-a-test")
 	resp := ts.DoRequest(req)
-	resp.AssertContentMatch(assert, `.*Resource ID: 2014/09/30/just-a-test.*`)
+	resp.AssertBodyContains(`Resource ID: 2014/09/30/just-a-test`)
 }
 
 // TestFallbackDefault tests the fallback to default.
@@ -157,9 +157,9 @@ func TestFallbackDefault(t *testing.T) {
 	err := mux.Register("testing", "index", NewTestHandler("default", assert))
 	assert.Nil(err)
 	// Perform test requests.
-	req := restaudit.NewRequest("GET", "/base/x/y")
+	req := restaudit.NewRequest(assert, "GET", "/base/x/y")
 	resp := ts.DoRequest(req)
-	resp.AssertContentMatch(assert, `.*Resource: y.*`)
+	resp.AssertBodyContains(`Resource: y`)
 }
 
 // TestHandlerStack tests a complete handler stack.
@@ -176,17 +176,16 @@ func TestHandlerStack(t *testing.T) {
 	})
 	assert.Nil(err)
 	// Perform test requests.
-	req := restaudit.NewRequest("GET", "/base/test/stack")
+	req := restaudit.NewRequest(assert, "GET", "/base/test/stack")
 	resp := ts.DoRequest(req)
-	resp.AssertContentMatch(assert, ".*Resource: token.*")
-	token := resp.AssertHeader(assert, "Token")
-	assert.Equal(token, "foo")
-	req = restaudit.NewRequest("GET", "/base/test/stack")
+	resp.AssertBodyContains("Resource: token")
+	resp.AssertHeaderEquals("Token", "foo")
+	req = restaudit.NewRequest(assert, "GET", "/base/test/stack")
 	req.AddHeader("token", "foo")
 	resp = ts.DoRequest(req)
-	resp.AssertContentMatch(assert, ".*Resource: stack.*")
+	resp.AssertBodyContains("Resource: stack")
 	resp = ts.DoRequest(req)
-	resp.AssertContentMatch(assert, ".*Resource: stack.*")
+	resp.AssertBodyContains("Resource: stack")
 }
 
 // TestVersion tests request and response version.
@@ -199,28 +198,25 @@ func TestVersion(t *testing.T) {
 	err := mux.Register("test", "json", NewTestHandler("json", assert))
 	assert.Nil(err)
 	// Perform test requests.
-	req := restaudit.NewRequest("GET", "/base/test/json/4711?foo=0815")
+	req := restaudit.NewRequest(assert, "GET", "/base/test/json/4711?foo=0815")
 	req.AddHeader(restaudit.HeaderAccept, restaudit.ApplicationJSON)
 	resp := ts.DoRequest(req)
-	resp.AssertStatus(assert, 200)
-	vsn := resp.AssertHeader(assert, "Version")
-	assert.Equal(vsn, "1.0.0")
+	resp.AssertStatusEquals(200)
+	resp.AssertHeaderEquals("Version", "1.0.0")
 
-	req = restaudit.NewRequest("GET", "/base/test/json/4711?foo=0815")
+	req = restaudit.NewRequest(assert, "GET", "/base/test/json/4711?foo=0815")
 	req.AddHeader(restaudit.HeaderAccept, restaudit.ApplicationJSON)
 	req.AddHeader("Version", "2")
 	resp = ts.DoRequest(req)
-	resp.AssertStatus(assert, 200)
-	vsn = resp.AssertHeader(assert, "Version")
-	assert.Equal(vsn, "2.0.0")
+	resp.AssertStatusEquals(200)
+	resp.AssertHeaderEquals("Version", "2.0.0")
 
-	req = restaudit.NewRequest("GET", "/base/test/json/4711?foo=0815")
+	req = restaudit.NewRequest(assert, "GET", "/base/test/json/4711?foo=0815")
 	req.AddHeader(restaudit.HeaderAccept, restaudit.ApplicationJSON)
 	req.AddHeader("Version", "3.0")
 	resp = ts.DoRequest(req)
-	resp.AssertStatus(assert, 200)
-	vsn = resp.AssertHeader(assert, "Version")
-	assert.Equal(vsn, "4.0.0-alpha")
+	resp.AssertStatusEquals(200)
+	resp.AssertHeaderEquals("Version", "4.0.0-alpha")
 }
 
 //  TestDeregister tests the different possibilities to stop handlers.
@@ -275,9 +271,9 @@ func TestMethodNotSupported(t *testing.T) {
 	err := mux.Register("test", "method", NewTestHandler("method", assert))
 	assert.Nil(err)
 	// Perform test requests.
-	req := restaudit.NewRequest("OPTION", "/base/test/method")
+	req := restaudit.NewRequest(assert, "OPTION", "/base/test/method")
 	resp := ts.DoRequest(req)
-	resp.AssertContentMatch(assert, ".*OPTION.*")
+	resp.AssertBodyContains("OPTION")
 }
 
 //--------------------

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -46,7 +46,7 @@ func TestGetJSON(t *testing.T) {
 	err := mux.Register("test", "json", NewTestHandler("json", assert))
 	assert.Nil(err)
 	// Perform test requests.
-	req := restaudit.NewRequest(assert, "GET", "/base/test/json/4711?foo=0815")
+	req := restaudit.NewRequest("GET", "/base/test/json/4711?foo=0815")
 	req.AddHeader(restaudit.HeaderAccept, restaudit.ApplicationJSON)
 	resp := ts.DoRequest(req)
 	resp.AssertStatusEquals(200)
@@ -65,13 +65,13 @@ func TestPutJSON(t *testing.T) {
 	err := mux.Register("test", "json", NewTestHandler("json", assert))
 	assert.Nil(err)
 	// Perform test requests.
-	req := restaudit.NewRequest(assert, "PUT", "/base/test/json/4711")
+	req := restaudit.NewRequest("PUT", "/base/test/json/4711")
 	reqData := TestRequestData{"foo", "bar", "4711", "0815", ""}
-	req.SetBody(restaudit.ApplicationJSON, reqData)
+	req.MarshalBody(assert, restaudit.ApplicationJSON, reqData)
 	resp := ts.DoRequest(req)
 	resp.AssertStatusEquals(200)
 	respData := TestRequestData{}
-	resp.AssertBody(&respData)
+	resp.AssertUnmarshalledBody(&respData)
 	assert.Equal(respData, reqData)
 }
 
@@ -85,7 +85,7 @@ func TestGetXML(t *testing.T) {
 	err := mux.Register("test", "xml", NewTestHandler("xml", assert))
 	assert.Nil(err)
 	// Perform test requests.
-	req := restaudit.NewRequest(assert, "GET", "/base/test/xml/4711")
+	req := restaudit.NewRequest("GET", "/base/test/xml/4711")
 	req.AddHeader(restaudit.HeaderAccept, restaudit.ApplicationXML)
 	resp := ts.DoRequest(req)
 	resp.AssertStatusEquals(200)
@@ -102,13 +102,13 @@ func TestPutXML(t *testing.T) {
 	err := mux.Register("test", "xml", NewTestHandler("xml", assert))
 	assert.Nil(err)
 	// Perform test requests.
-	req := restaudit.NewRequest(assert, "PUT", "/base/test/xml/4711")
+	req := restaudit.NewRequest("PUT", "/base/test/xml/4711")
 	reqData := TestRequestData{"foo", "bar", "4711", "0815", ""}
-	req.SetBody(restaudit.ApplicationXML, reqData)
+	req.MarshalBody(assert, restaudit.ApplicationXML, reqData)
 	resp := ts.DoRequest(req)
 	resp.AssertStatusEquals(200)
 	respData := TestRequestData{}
-	resp.AssertBody(&respData)
+	resp.AssertUnmarshalledBody(&respData)
 	assert.Equal(respData, reqData)
 }
 
@@ -122,13 +122,13 @@ func TestPutGOB(t *testing.T) {
 	err := mux.Register("test", "gob", NewTestHandler("putgob", assert))
 	assert.Nil(err)
 	// Perform test requests.
-	req := restaudit.NewRequest(assert, "POST", "/base/test/gob")
+	req := restaudit.NewRequest("POST", "/base/test/gob")
 	reqData := TestCounterData{"test", 4711}
-	req.SetBody(restaudit.ApplicationGOB, reqData)
+	req.MarshalBody(assert, restaudit.ApplicationGOB, reqData)
 	resp := ts.DoRequest(req)
 	resp.AssertStatusEquals(200)
 	respData := TestCounterData{}
-	resp.AssertBody(&respData)
+	resp.AssertUnmarshalledBody(&respData)
 	assert.Equal(respData, reqData)
 }
 
@@ -142,7 +142,7 @@ func TestLongPath(t *testing.T) {
 	err := mux.Register("content", "blog", NewTestHandler("default", assert))
 	assert.Nil(err)
 	// Perform test requests.
-	req := restaudit.NewRequest(assert, "GET", "/base/content/blog/2014/09/30/just-a-test")
+	req := restaudit.NewRequest("GET", "/base/content/blog/2014/09/30/just-a-test")
 	resp := ts.DoRequest(req)
 	resp.AssertBodyContains(`Resource ID: 2014/09/30/just-a-test`)
 }
@@ -157,7 +157,7 @@ func TestFallbackDefault(t *testing.T) {
 	err := mux.Register("testing", "index", NewTestHandler("default", assert))
 	assert.Nil(err)
 	// Perform test requests.
-	req := restaudit.NewRequest(assert, "GET", "/base/x/y")
+	req := restaudit.NewRequest("GET", "/base/x/y")
 	resp := ts.DoRequest(req)
 	resp.AssertBodyContains(`Resource: y`)
 }
@@ -176,11 +176,11 @@ func TestHandlerStack(t *testing.T) {
 	})
 	assert.Nil(err)
 	// Perform test requests.
-	req := restaudit.NewRequest(assert, "GET", "/base/test/stack")
+	req := restaudit.NewRequest("GET", "/base/test/stack")
 	resp := ts.DoRequest(req)
 	resp.AssertBodyContains("Resource: token")
 	resp.AssertHeaderEquals("Token", "foo")
-	req = restaudit.NewRequest(assert, "GET", "/base/test/stack")
+	req = restaudit.NewRequest("GET", "/base/test/stack")
 	req.AddHeader("token", "foo")
 	resp = ts.DoRequest(req)
 	resp.AssertBodyContains("Resource: stack")
@@ -198,20 +198,20 @@ func TestVersion(t *testing.T) {
 	err := mux.Register("test", "json", NewTestHandler("json", assert))
 	assert.Nil(err)
 	// Perform test requests.
-	req := restaudit.NewRequest(assert, "GET", "/base/test/json/4711?foo=0815")
+	req := restaudit.NewRequest("GET", "/base/test/json/4711?foo=0815")
 	req.AddHeader(restaudit.HeaderAccept, restaudit.ApplicationJSON)
 	resp := ts.DoRequest(req)
 	resp.AssertStatusEquals(200)
 	resp.AssertHeaderEquals("Version", "1.0.0")
 
-	req = restaudit.NewRequest(assert, "GET", "/base/test/json/4711?foo=0815")
+	req = restaudit.NewRequest("GET", "/base/test/json/4711?foo=0815")
 	req.AddHeader(restaudit.HeaderAccept, restaudit.ApplicationJSON)
 	req.AddHeader("Version", "2")
 	resp = ts.DoRequest(req)
 	resp.AssertStatusEquals(200)
 	resp.AssertHeaderEquals("Version", "2.0.0")
 
-	req = restaudit.NewRequest(assert, "GET", "/base/test/json/4711?foo=0815")
+	req = restaudit.NewRequest("GET", "/base/test/json/4711?foo=0815")
 	req.AddHeader(restaudit.HeaderAccept, restaudit.ApplicationJSON)
 	req.AddHeader("Version", "3.0")
 	resp = ts.DoRequest(req)
@@ -271,7 +271,7 @@ func TestMethodNotSupported(t *testing.T) {
 	err := mux.Register("test", "method", NewTestHandler("method", assert))
 	assert.Nil(err)
 	// Perform test requests.
-	req := restaudit.NewRequest(assert, "OPTION", "/base/test/method")
+	req := restaudit.NewRequest("OPTION", "/base/test/method")
 	resp := ts.DoRequest(req)
 	resp.AssertBodyContains("OPTION")
 }

--- a/restaudit/doc.go
+++ b/restaudit/doc.go
@@ -10,6 +10,44 @@
 // resource handlers. Requests can easily be created, marshalling data
 // based on the content-type is done automatically. Response also
 // provides assert methods for the tests.
+//
+// So first step is to create a test server and register the handler(s)
+// to test. Could best be done with a little helper function, depending
+// on own needs, e.g. when the context shall contain more information.
+//
+//     assert := audit.NewTestingAssertion(t, true)
+//     cfgStr := "{etc {basepath /}{default-domain testing}{default-resource index}}"
+//     cfg, err := etc.ReadString(cfgStr)
+//     assert.Nil(err)
+//     mux := rest.NewMultiplexer(context.Background(), cfg)
+//     ts := restaudit.StartServer(mux, assert)
+//     defer ts.Close()
+//     err := mux.Register("my-domain", "my-resource", NewMyHandler())
+//     assert.Nil(err)
+//
+// During the tests you create the requests with
+//
+//     req := restaudit.NewRequest("GET", "/my-domain/my-resource/4711")
+//     req.AddHeader(restaudit.HeaderAccept, restaudit.ApplicationJSON)
+//
+// The request the is done with
+//
+//     resp := ts.DoRequest(req)
+//     resp.AssertStatusEquals(200)
+//     rest.AssertHeaderContains(restaudit.HeaderContentType, restaudit.ApplicationJSON)
+//     resp.AssertBodyContains(`"ResourceID":"4711"`)
+//
+// Also data can be marshalled including setting the content type
+// and the response can be unmarshalled based on that type.
+//
+//     req.MarshalBody(assert, restaudit.ApplicationJSON, myInData)
+//     ...
+//     var myOutData MyType
+//     resp.AssertUnmarshalledBody(&myOutData)
+//     assert.Equal(myOutData.MyField, "foo")
+//
+// There are more helpers for a convenient test, but the fields of
+// Request and Response can also be accessed directly.
 package restaudit
 
 // EOF


### PR DESCRIPTION
- Some renamings in *Request*  and *Response*, sadly to the previous minor release
- More convenience helpers for testing
- Adopted new testing to more packages
- Using *http* package constants instead of own plain strings
- Added documentation to *restaudit*