### PR TITLE
Release 2.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Rename internal *envelope* to public *Feedback* in *rest*
 - Added *ReadFeedback()* to *Response* in *request*
+- Asserts in *restaudit* now internally increase the callstack 
+  offset so that the correct test line number is shown
 
 ## 2017-02-12
 
@@ -13,7 +15,7 @@
 - Adopted new testing to more packages
 - Using http package constants instead of own
   plain strings
-- Added documentation to restaudit
+- Added documentation to *restaudit*
 
 ## 2017-02-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Tideland Go REST Server Library
 
+## 2017-03-XX
+
+- Rename internal *envelope* to public *Feedback* in *rest*
+- Added *ReadFeedback()* to *Response* in *request*
+
 ## 2017-02-12
 
 - Some renamings in *Request*  and *Response*, sadly
-  to the previous minor release
+  incompatible to the previous minor release
 - More convenience helpers for testing
 - Adopted new testing to more packages
 - Using http package constants instead of own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added *ReadFeedback()* to *Response* in *request*
 - Asserts in *restaudit* now internally increase the callstack 
   offset so that the correct test line number is shown
+- Added *Response.AssertBodyGrep()* to *restaudit*
 
 ## 2017-02-12
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ I hope you like it. ;)
 
 ## Version
 
-Version 2.12.0
+Version 2.13.0
 
 ## Packages
 

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -54,6 +54,8 @@ func TestWrapperHandler(t *testing.T) {
 	req := restaudit.NewRequest("GET", "/test/wrapper")
 	resp := ts.DoRequest(req)
 	resp.AssertBodyContains(data)
+	punctuation := resp.AssertBodyGrep("[,!]")
+	assert.Length(punctuation, 2)
 }
 
 // TestFileServeHandler tests the serving of files.

--- a/request/request.go
+++ b/request/request.go
@@ -128,6 +128,10 @@ type Response interface {
 	// Read decodes the content into the passed data depending
 	// on the content type.
 	Read(data interface{}) error
+
+	// ReadFeedback tries to unmarshal the content of the
+	// response into a rest package feedback.
+	ReadFeedback() (rest.Feedback, bool)
 }
 
 // response implements Response.
@@ -195,6 +199,16 @@ func (r *response) Read(data interface{}) error {
 		return nil
 	}
 	return errors.New(ErrInvalidContentType, errorMessages, r.contentType)
+}
+
+// ReadFeedback implements the Response interface.
+func (r *response) ReadFeedback() (rest.Feedback, bool) {
+	fb := rest.Feedback{}
+	err := r.Read(&fb)
+	if err != nil {
+		return rest.Feedback{}, false
+	}
+	return fb, true
 }
 
 //--------------------

--- a/restaudit/restaudit.go
+++ b/restaudit/restaudit.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/tideland/golib/audit"
+	"github.com/tideland/gorest/rest"
 )
 
 //--------------------
@@ -234,6 +235,14 @@ func (r *Response) AssertUnmarshalledBody(data interface{}) {
 	default:
 		r.assert.Fail("unknown content type: " + contentType)
 	}
+}
+
+// AssertUnmarshalledFeedback retrieves a rest.Feedback as body out of
+// response and returns it for further tests.
+func (r *Response) AssertUnmarshalledFeedback() rest.Feedback {
+	fb := rest.Feedback{}
+	r.AssertUnmarshalledBody(&fb)
+	return fb
 }
 
 // AssertBodyMatches checks if the body matches a regular expression.

--- a/restaudit/restaudit.go
+++ b/restaudit/restaudit.go
@@ -168,11 +168,15 @@ type Response struct {
 
 // AssertStatusEquals checks if the status is the expected one.
 func (r *Response) AssertStatusEquals(expected int) {
+	restore := r.assert.IncrCallstackOffset()
+	defer restore()
 	r.assert.Equal(r.Status, expected, "response status differs")
 }
 
 // AssertHeader checks if a header exists and retrieves it.
 func (r *Response) AssertHeader(key string) string {
+	restore := r.assert.IncrCallstackOffset()
+	defer restore()
 	r.assert.NotEmpty(r.Header, "response contains no header")
 	value, ok := r.Header[key]
 	r.assert.True(ok, "header '"+key+"' not found")
@@ -182,6 +186,8 @@ func (r *Response) AssertHeader(key string) string {
 // AssertHeaderEquals checks if a header exists and compares
 // it to an expected one.
 func (r *Response) AssertHeaderEquals(key, expected string) {
+	restore := r.assert.IncrCallstackOffset()
+	defer restore()
 	value := r.AssertHeader(key)
 	r.assert.Equal(value, expected, "header value is not equal to expected")
 }
@@ -189,12 +195,16 @@ func (r *Response) AssertHeaderEquals(key, expected string) {
 // AssertHeaderContains checks if a header exists and looks for
 // an expected part.
 func (r *Response) AssertHeaderContains(key, expected string) {
+	restore := r.assert.IncrCallstackOffset()
+	defer restore()
 	value := r.AssertHeader(key)
 	r.assert.Substring(expected, value, "header value does not contain expected")
 }
 
 // AssertCookie checks if a cookie exists and retrieves it.
 func (r *Response) AssertCookie(key string) string {
+	restore := r.assert.IncrCallstackOffset()
+	defer restore()
 	r.assert.NotEmpty(r.Cookies, "response contains no cookies")
 	value, ok := r.Cookies[key]
 	r.assert.True(ok, "cookie '"+key+"' not found")
@@ -204,6 +214,8 @@ func (r *Response) AssertCookie(key string) string {
 // AssertCookieEquals checks if a cookie exists and compares
 // it to an expected one.
 func (r *Response) AssertCookieEquals(key, expected string) {
+	restore := r.assert.IncrCallstackOffset()
+	defer restore()
 	value := r.AssertCookie(key)
 	r.assert.Equal(value, expected, "cookie value is not equal to expected")
 }
@@ -211,6 +223,8 @@ func (r *Response) AssertCookieEquals(key, expected string) {
 // AssertCookieContains checks if a cookie exists and looks for
 // an expected part.
 func (r *Response) AssertCookieContains(key, expected string) {
+	restore := r.assert.IncrCallstackOffset()
+	defer restore()
 	value := r.AssertCookie(key)
 	r.assert.Substring(expected, value, "cookie value does not contain expected")
 }
@@ -218,6 +232,8 @@ func (r *Response) AssertCookieContains(key, expected string) {
 // AssertUnmarshalledBody retrieves the body based on the content type
 // and unmarshals it accordingly.
 func (r *Response) AssertUnmarshalledBody(data interface{}) {
+	restore := r.assert.IncrCallstackOffset()
+	defer restore()
 	contentType, ok := r.Header[HeaderContentType]
 	r.assert.True(ok)
 	switch contentType {
@@ -240,6 +256,8 @@ func (r *Response) AssertUnmarshalledBody(data interface{}) {
 // AssertUnmarshalledFeedback retrieves a rest.Feedback as body out of
 // response and returns it for further tests.
 func (r *Response) AssertUnmarshalledFeedback() rest.Feedback {
+	restore := r.assert.IncrCallstackOffset()
+	defer restore()
 	fb := rest.Feedback{}
 	r.AssertUnmarshalledBody(&fb)
 	return fb
@@ -247,6 +265,8 @@ func (r *Response) AssertUnmarshalledFeedback() rest.Feedback {
 
 // AssertBodyMatches checks if the body matches a regular expression.
 func (r *Response) AssertBodyMatches(pattern string) {
+	restore := r.assert.IncrCallstackOffset()
+	defer restore()
 	ok, err := regexp.MatchString(pattern, string(r.Body))
 	r.assert.Nil(err, "illegal content match pattern")
 	r.assert.True(ok, "body doesn't match pattern")
@@ -254,6 +274,8 @@ func (r *Response) AssertBodyMatches(pattern string) {
 
 // AssertBodyContains checks if the body contains a string.
 func (r *Response) AssertBodyContains(expected string) {
+	restore := r.assert.IncrCallstackOffset()
+	defer restore()
 	r.assert.Contents(expected, r.Body, "body doesn't contains expected")
 }
 

--- a/restaudit/restaudit.go
+++ b/restaudit/restaudit.go
@@ -272,6 +272,15 @@ func (r *Response) AssertBodyMatches(pattern string) {
 	r.assert.True(ok, "body doesn't match pattern")
 }
 
+// AssertBodyGrep greps content out of the body.
+func (r *Response) AssertBodyGrep(pattern string) []string {
+	restore := r.assert.IncrCallstackOffset()
+	defer restore()
+	expr, err := regexp.Compile(pattern)
+	r.assert.Nil(err, "illegal content grep pattern")
+	return expr.FindAllString(string(r.Body), -1)
+}
+
 // AssertBodyContains checks if the body contains a string.
 func (r *Response) AssertBodyContains(expected string) {
 	restore := r.assert.IncrCallstackOffset()


### PR DESCRIPTION
- Rename internal *envelope* to public *Feedback* in *rest*
- Added *ReadFeedback()* to *Response* in *request*
- Asserts in *restaudit* now internally increase the callstack 
  offset so that the correct test line number is shown
- Added *Response.AssertBodyGrep()* to *restaudit*