### PR TITLE
Released v2.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Tideland Go REST Server Library
 
+## 2017-04-25
+
+- Added access to URL path parts via *Job.Path()*
+- Added interfaces for handler methods directly mapping
+  HTTP verbs to the according REST methods like *Create()*,
+  *Read()*, *Update()*, *Modify()*, *Delete()*, and *Info()*
+
 ## 2017-03-20
 
 - Rename internal *envelope* to public *Feedback* in *rest*
 - Added *ReadFeedback()* to *Response* in *request*
-- Asserts in *restaudit* now internally increase the callstack 
+- Asserts in *restaudit* now internally increase the callstack
   offset so that the correct test line number is shown
 - Added *Response.AssertBodyGrep()* to *restaudit*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Tideland Go REST Server Library
 
-## 2017-04-25
+## 2017-04-26
 
 - Added access to URL path parts via *Job.Path()*
 - Added interfaces for handler methods directly mapping

--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ The library earlier has been known as `web` package of the
 
 I hope you like it. ;)
 
+[![GoDoc](https://godoc.org/github.com/tideland/gorest?status.svg)](https://godoc.org/github.com/tideland/gorestt)
 [![Sourcegraph](https://sourcegraph.com/github.com/tideland/gorest/-/badge.svg)](https://sourcegraph.com/github.com/tideland/gorest?badge)
 [![Go Report Card](https://goreportcard.com/badge/github.com/tideland/gorest)](https://goreportcard.com/report/github.com/tideland/gorest)
 
 ## Version
 
-Version 2.13.1
+Version 2.14.0
 
 ## Packages
 
@@ -25,31 +26,21 @@ Version 2.13.1
 
 RESTful web request handling.
 
-[![GoDoc](https://godoc.org/github.com/tideland/gorest/rest?status.svg)](https://godoc.org/github.com/tideland/gorest/rest)
-
 ### Request
 
 Convenient client requests to RESTful web services.
-
-[![GoDoc](https://godoc.org/github.com/tideland/gorest/request?status.svg)](https://godoc.org/github.com/tideland/gorest/request)
 
 ### Handlers
 
 Some general purpose handlers for the library.
 
-[![GoDoc](https://godoc.org/github.com/tideland/gorest/handlers?status.svg)](https://godoc.org/github.com/tideland/gorest/handlers)
-
 ### JSON Web Token
 
 JWT package for secure authentication and information exchange like claims.
 
-[![GoDoc](https://godoc.org/github.com/tideland/gorest/jwt?status.svg)](https://godoc.org/github.com/tideland/gorest/jwt)
-
 ### REST Audit
 
 Helpers for the unit tests of the Go REST Server Library.
-
-[![GoDoc](https://godoc.org/github.com/tideland/gorest/restaudit?status.svg)](https://godoc.org/github.com/tideland/gorest/restaudit)
 
 ## Contributors
 

--- a/request/request.go
+++ b/request/request.go
@@ -206,7 +206,12 @@ func (r *response) ReadFeedback() (rest.Feedback, bool) {
 	fb := rest.Feedback{}
 	err := r.Read(&fb)
 	if err != nil {
-		return rest.Feedback{}, false
+		return rest.Feedback{
+			StatusCode: -1,
+			Status:     "fail",
+			Message:    err.Error(),
+			Payload:    r.content,
+		}, false
 	}
 	return fb, true
 }

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -122,61 +122,66 @@ func handleJob(handler ResourceHandler, job Job) (bool, error) {
 	switch job.Request().Method {
 	case http.MethodGet:
 		grh, ok := handler.(GetResourceHandler)
-		if !ok {
-			grh, ok = handler.(ReadResourceHandler)
-			if !ok {
-				return false, errors.New(ErrNoGetHandler, errorMessages, id())
-			}
+		if ok {
+			return grh.Get(job)
 		}
-		return grh.Get(job)
+		rrh, ok := handler.(ReadResourceHandler)
+		if ok {
+			return rrh.Read(job)
+		}
+		return false, errors.New(ErrNoGetHandler, errorMessages, id())
 	case http.MethodHead:
 		hrh, ok := handler.(HeadResourceHandler)
-		if !ok {
-			return false, errors.New(ErrNoHeadHandler, errorMessages, id())
+		if ok {
+			return hrh.Head(job)
 		}
-		return hrh.Head(job)
+		return false, errors.New(ErrNoHeadHandler, errorMessages, id())
 	case http.MethodPut:
 		prh, ok := handler.(PutResourceHandler)
-		if !ok {
-			prh, ok = handler.(UpdateResourceHandler)
-			if !ok {
-				return false, errors.New(ErrNoPutHandler, errorMessages, id())
-			}
+		if ok {
+			return prh.Put(job)
 		}
-		return prh.Put(job)
+		urh, ok := handler.(UpdateResourceHandler)
+		if ok {
+			return urh.Update(job)
+		}
+		return false, errors.New(ErrNoPutHandler, errorMessages, id())
 	case http.MethodPost:
 		prh, ok := handler.(PostResourceHandler)
-		if !ok {
-			prh, ok = handler.(CreateResourceHandler)
-			if !ok {
-				return false, errors.New(ErrNoPostHandler, errorMessages, id())
-			}
+		if ok {
+			return prh.Post(job)
 		}
-		return prh.Post(job)
+		crh, ok := handler.(CreateResourceHandler)
+		if ok {
+			return crh.Create(job)
+		}
+		return false, errors.New(ErrNoPostHandler, errorMessages, id())
 	case http.MethodPatch:
 		prh, ok := handler.(PatchResourceHandler)
-		if !ok {
-			prh, ok = handler.(ModifyResourceHandler)
-			if !ok {
-				return false, errors.New(ErrNoPatchHandler, errorMessages, id())
-			}
+		if ok {
+			return prh.Patch(job)
 		}
-		return prh.Patch(job)
+		mrh, ok := handler.(ModifyResourceHandler)
+		if ok {
+			return mrh.Modify(job)
+		}
+		return false, errors.New(ErrNoPatchHandler, errorMessages, id())
 	case http.MethodDelete:
 		drh, ok := handler.(DeleteResourceHandler)
-		if !ok {
-			return false, errors.New(ErrNoDeleteHandler, errorMessages, id())
+		if ok {
+			return drh.Delete(job)
 		}
-		return drh.Delete(job)
+		return false, errors.New(ErrNoDeleteHandler, errorMessages, id())
 	case http.MethodOptions:
 		orh, ok := handler.(OptionsResourceHandler)
-		if !ok {
-			orh, ok = handler.(InfoResourceHandler)
-			if !ok {
-				return false, errors.New(ErrNoOptionsHandler, errorMessages, id())
-			}
+		if ok {
+			return orh.Options(job)
 		}
-		return orh.Options(job)
+		irh, ok := handler.(InfoResourceHandler)
+		if ok {
+			return irh.Info(job)
+		}
+		return false, errors.New(ErrNoOptionsHandler, errorMessages, id())
 	}
 	return false, errors.New(ErrMethodNotSupported, errorMessages, job.Request().Method)
 }

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -41,6 +41,13 @@ type GetResourceHandler interface {
 	Get(job Job) (bool, error)
 }
 
+// ReadResourceHandler is the additional interface for
+// handlers understanding the verb GET but mapping it
+// to method Read() according to the REST conventions.
+type ReadResourceHandler interface {
+	Read(job Job) (bool, error)
+}
+
 // HeadResourceHandler is the additional interface for
 // handlers understanding the verb HEAD.
 type HeadResourceHandler interface {
@@ -53,16 +60,37 @@ type PutResourceHandler interface {
 	Put(job Job) (bool, error)
 }
 
+// UpdateResourceHandler is the additional interface for
+// handlers understanding the verb PUT but mapping it
+// to method Update() according to the REST conventions.
+type UpdateResourceHandler interface {
+	Update(job Job) (bool, error)
+}
+
 // PostResourceHandler is the additional interface for
 // handlers understanding the verb POST.
 type PostResourceHandler interface {
 	Post(job Job) (bool, error)
 }
 
+// CreateResourceHandler is the additional interface for
+// handlers understanding the verb POST but mapping it
+// to method Create() according to the REST conventions.
+type CreateResourceHandler interface {
+	Create(job Job) (bool, error)
+}
+
 // PatchResourceHandler is the additional interface for
 // handlers understanding the verb PATCH.
 type PatchResourceHandler interface {
 	Patch(job Job) (bool, error)
+}
+
+// ModifyResourceHandler is the additional interface for
+// handlers understanding the verb PATCH but mapping it
+// to method Modify() according to the REST conventions.
+type ModifyResourceHandler interface {
+	Modify(job Job) (bool, error)
 }
 
 // DeleteResourceHandler is the additional interface for
@@ -77,8 +105,16 @@ type OptionsResourceHandler interface {
 	Options(job Job) (bool, error)
 }
 
+// InfoResourceHandler is the additional interface for
+// handlers understanding the verb OPTION but mapping it
+// to method Info() according to the REST conventions.
+type InfoResourceHandler interface {
+	Info(job Job) (bool, error)
+}
+
 // handleJob dispatches the passed job to the right method of the
-// passed handler.
+// passed handler. It always tries the nativ method first, then
+// the alias method according to the REST conventions.
 func handleJob(handler ResourceHandler, job Job) (bool, error) {
 	id := func() string {
 		return fmt.Sprintf("%s@%s/%s", handler.ID(), job.Domain(), job.Resource())
@@ -87,7 +123,10 @@ func handleJob(handler ResourceHandler, job Job) (bool, error) {
 	case http.MethodGet:
 		grh, ok := handler.(GetResourceHandler)
 		if !ok {
-			return false, errors.New(ErrNoGetHandler, errorMessages, id())
+			grh, ok = handler.(ReadResourceHandler)
+			if !ok {
+				return false, errors.New(ErrNoGetHandler, errorMessages, id())
+			}
 		}
 		return grh.Get(job)
 	case http.MethodHead:
@@ -99,19 +138,28 @@ func handleJob(handler ResourceHandler, job Job) (bool, error) {
 	case http.MethodPut:
 		prh, ok := handler.(PutResourceHandler)
 		if !ok {
-			return false, errors.New(ErrNoPutHandler, errorMessages, id())
+			prh, ok = handler.(UpdateResourceHandler)
+			if !ok {
+				return false, errors.New(ErrNoPutHandler, errorMessages, id())
+			}
 		}
 		return prh.Put(job)
 	case http.MethodPost:
 		prh, ok := handler.(PostResourceHandler)
 		if !ok {
-			return false, errors.New(ErrNoPostHandler, errorMessages, id())
+			prh, ok = handler.(CreateResourceHandler)
+			if !ok {
+				return false, errors.New(ErrNoPostHandler, errorMessages, id())
+			}
 		}
 		return prh.Post(job)
 	case http.MethodPatch:
 		prh, ok := handler.(PatchResourceHandler)
 		if !ok {
-			return false, errors.New(ErrNoPatchHandler, errorMessages, id())
+			prh, ok = handler.(ModifyResourceHandler)
+			if !ok {
+				return false, errors.New(ErrNoPatchHandler, errorMessages, id())
+			}
 		}
 		return prh.Patch(job)
 	case http.MethodDelete:
@@ -123,7 +171,10 @@ func handleJob(handler ResourceHandler, job Job) (bool, error) {
 	case http.MethodOptions:
 		orh, ok := handler.(OptionsResourceHandler)
 		if !ok {
-			return false, errors.New(ErrNoOptionsHandler, errorMessages, id())
+			orh, ok = handler.(InfoResourceHandler)
+			if !ok {
+				return false, errors.New(ErrNoOptionsHandler, errorMessages, id())
+			}
 		}
 		return orh.Options(job)
 	}

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -146,6 +146,11 @@ func TestLongPath(t *testing.T) {
 	req := restaudit.NewRequest("GET", "/base/content/blog/2014/09/30/just-a-test")
 	resp := ts.DoRequest(req)
 	resp.AssertBodyContains(`Resource ID: 2014/09/30/just-a-test`)
+	// Now with path elements.
+	req = restaudit.NewRequest("GET", "/base/content/blog/2014/09/30/just-another-test")
+	req.AddHeader(restaudit.HeaderAccept, rest.ContentTypePlain)
+	resp = ts.DoRequest(req)
+	resp.AssertBodyContains(`0: "content" 1: "blog" 2: "2014" 3: "09" 4: "30" 5: "just-another-test" 6: ""`)
 }
 
 // TestFallbackDefault tests the fallback to default.

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -13,6 +13,7 @@ package rest_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/tideland/golib/audit"
@@ -387,6 +388,16 @@ func (th *TestHandler) Get(job rest.Job) (bool, error) {
 	case job.AcceptsContentType(rest.ContentTypeJSON):
 		th.assert.Logf("GET JSON")
 		job.JSON(true).Write(rest.StatusOK, data)
+	case job.AcceptsContentType(rest.ContentTypePlain):
+		p0 := job.Path(rest.PathDomain)
+		p1 := job.Path(rest.PathResource)
+		p2 := job.Path(2)
+		p3 := job.Path(3)
+		p4 := job.Path(4)
+		p5 := job.Path(5)
+		p6 := job.Path(6)
+		s := fmt.Sprintf("0: %q 1: %q 2: %q 3: %q 4: %q 5: %q 6: %q", p0, p1, p2, p3, p4, p5, p6)
+		job.ResponseWriter().Write([]byte(s))
 	default:
 		th.assert.Logf("GET HTML")
 		job.Renderer().Render("test:context:html", data)
@@ -416,7 +427,6 @@ func (th *TestHandler) Put(job rest.Job) (bool, error) {
 			job.XML().Write(rest.StatusOK, data)
 		}
 	}
-
 	return true, nil
 }
 


### PR DESCRIPTION
- Added access to URL path parts via *Job.Path()*
- Added interfaces for handler methods directly mapping HTTP verbs to the according REST methods like *Create()*, *Read()*, *Update()*, *Modify()*, *Delete()*, and *Info()*
